### PR TITLE
Don't expect JSON from a Gandi DELETE

### DIFF
--- a/lancer/_gandi.py
+++ b/lancer/_gandi.py
@@ -16,7 +16,7 @@ class GandiV5Responder(object):
 
     _api_key = attr.ib()
     _zone_name = attr.ib()
-    _settle_delay=attr.ib(default=60.0)
+    _settle_delay = attr.ib(default=60.0)
 
     challenge_type = u'dns-01'
 
@@ -67,6 +67,6 @@ class GandiV5Responder(object):
         if subdomain == '':
             subdomain = '@'
         response = yield treq.delete(url, headers=self._headers())
-        print((yield treq.json_content(response)))
+        print((yield treq.text(response)))
         yield deferLater(reactor, self._settle_delay, lambda: None)
         print("stop settled")


### PR DESCRIPTION
`lancer` wanted JSON in response to a HTTP DELETE, but Gandi doesn't provide a body. This change allowed me to successfully create some certificates. Thank you, @glyph!

```
2018-07-17T21:14:02-0700 [txacme.service#critical] PANIC! Unable to renew certificate for: 'jame.twm.space'
   Traceback (most recent call last):
     File ".../lancer/lib/python3.6/site-packages/lancer/_gandi.py", line 70, in stop_responding
       print((yield treq.json_content(response)))
     File ".../lancer/lib/python3.6/site-packages/treq/content.py", line 101, in json_content
       d.addCallback(lambda text: json.loads(text, **kwargs))
     File ".../lancer/lib/python3.6/site-packages/twisted/internet/defer.py", line 322, in addCallback
       callbackKeywords=kw)
     File ".../lancer/lib/python3.6/site-packages/twisted/internet/defer.py", line 311, in addCallbacks
       self._runCallbacks()
   --- <exception caught here> ---
     File ".../lancer/lib/python3.6/site-packages/lancer/_gandi.py", line 70, in stop_responding
       print((yield treq.json_content(response)))
     File ".../lancer/lib/python3.6/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
       current.result = callback(current.result, *args, **kw)
     File ".../lancer/lib/python3.6/site-packages/treq/content.py", line 101, in <lambda>
       d.addCallback(lambda text: json.loads(text, **kwargs))
     File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
       return _default_decoder.decode(s)
     File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
       obj, end = self.raw_decode(s, idx=_w(s, 0).end())
     File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
       raise JSONDecodeError("Expecting value", s, err.value) from None
   json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```